### PR TITLE
fix: make sure the Polar subscription is active on `subscription.updated`

### DIFF
--- a/apps/web/src/app/api/webhook/polar/route.ts
+++ b/apps/web/src/app/api/webhook/polar/route.ts
@@ -38,6 +38,11 @@ export const POST = Webhooks({
           break;
         }
 
+        // Make sure the subscription is active before setting the plan
+        if (payload.data.status !== 'active') {
+          break;
+        }
+
         await updateOrganization({
           id: payload.data.metadata.organizationId as string,
           polarCustomerId: payload.data.customerId!,


### PR DESCRIPTION
The `subscription.updated` event is sent whenever something happens on a subscription, including cancellation, revokation, or past due payment.

This is why we should check the `status` property before enabling the pro plan on the organization.